### PR TITLE
Add new two log senders

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,23 @@ Example:
 <14>1 2016-03-31T19:19:02.524Z graylog unknown - nginx [all@0 request_verb="GET" remote_addr="192.168.1.37" response_status="404" from_nginx="true" level="6" connection_requests="1" http_version="1.1" response_bytes="1906" source="nginx" message="GET /test1/x HTTP/1.1" gl2_source_input="566c96abe4b094dfbc2661a8" version="1.1" nginx_access="true" http_user_agent="Wget/1.15 (linux-gnu)" remote_user="-" connection_id="970" http_referer="-" request_path="/test1/x" gl2_source_node="bebd092c-85d7-49a3-8188-f7af734747fb" _id="6d833da0-f775-11e5-b30c-0800276c97db" millis="0.002" facility="runit-service" timestamp="2016-03-31T19:19:02.000Z"] source: nginx | message: GET /test1/x HTTP/1.1 { request_verb: GET | remote_addr: 192.168.1.37 | response_status: 404 | from_nginx: true | level: 6 | connection_requests: 1 | http_version: 1.1 | response_bytes: 1906 | gl2_source_input: 566c96abe4b094dfbc2661a8 | version: 1.1 | nginx_access: true | http_user_agent: Wget/1.15 (linux-gnu) | remote_user: - | connection_id: 970 | http_referer: - | request_path: /test1/x | gl2_source_node: bebd092c-85d7-49a3-8188-f7af734747fb | _id: 6d833da0-f775-11e5-b30c-0800276c97db | millis: 0.002 | facility: runit-service | timestamp: 2016-03-31T19:19:02.000Z }
 ````
 
+### trasparent syslog
+
+A variation of plain sender without facility and source (there are in
+original message).
+Example:
+````
+<14>Feb 11 17:32:06 graylog01 sshd[26524]: Failed password for admin7 from 10.128.230.28 port 58363 ssh2
+````
+
+### snare windows
+
+Re-build a snare log format of windows event in stream.
+Example:
+````
+<14>Feb 11 17:32:26 graylog01 MSWinEventLog	1	Security	65493	Mon Feb 11 17:32:26 2019	4726	Microsoft-Windows-Security-Auditing	N/A	N/A	AUDIT_SUCCESS	WIN-8F8OSAB5AMC.testwin.lan	User Account Management		A user account was deleted.  Subject:  Security ID:  S-1-5-21-2081084977-3747244460-254679223-500  Account Name:  Administrator  Account Domain:  TESTWIN  Logon ID:  0x5F1B5  Target Account:  Security ID:  S-1-5-21-2081084977-3747244460-254679223-1126  Account Name:  admintest  Account Domain:  TESTWIN  Additional Information:  Privileges -	65493
+````
+
 ### custom:FQCN
 
 Specify your implementation of com.wizecore.graylog2.plugin.MessageSender interface.

--- a/src/main/java/com/wizecore/graylog2/plugin/SnareWindowsSender.java
+++ b/src/main/java/com/wizecore/graylog2/plugin/SnareWindowsSender.java
@@ -1,0 +1,171 @@
+package com.wizecore.graylog2.plugin;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.logging.Logger;
+
+import org.graylog2.plugin.Message;
+import org.graylog2.syslog4j.SyslogIF;
+
+/**
+ * Formats fields into message text 
+ * 
+
+        <34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 - BOM'su root' failed for lonvick on /dev/pts/8
+         ^priority
+         	^ version
+         	  ^ date 
+         	  						   ^ host
+         	  						   						 ^ APP-NAME
+         	  						   						 	^ structured data?
+         	  						   						 	  ^ MSGID 
+         	  						   						 	  	    
+ */
+public class SnareWindowsSender implements MessageSender {
+	private Logger log = Logger.getLogger(SnareWindowsSender.class.getName());
+
+	public static final String SYSLOG_DATEFORMAT = "MMM dd HH:mm:ss";
+  public static final String MSEVENT_DATEFORMAT = "EEE MMM dd HH:mm:ss yyyy";
+	public static final String SEPARATOR = "\t";
+	/**
+	 * From syslog4j
+	 * 
+	 * @param dt
+	 * @return
+	 */
+	public static void appendSyslogTimestamp(Date dt, StringBuilder buffer) {
+		SimpleDateFormat dateFormat = new SimpleDateFormat(SYSLOG_DATEFORMAT,Locale.ENGLISH);		
+		String datePrefix = dateFormat.format(dt);	
+		
+		int pos = buffer.length() + 4;		
+		buffer.append(datePrefix);
+	
+		//  RFC 3164 requires leading space for days 1-9
+		if (buffer.charAt(pos) == '0') {
+			buffer.setCharAt(pos,' ');
+		}
+	}
+
+	public static void appendMSEventTimestamp(Date dt, StringBuilder buffer) {
+		SimpleDateFormat dateFormat = new SimpleDateFormat(MSEVENT_DATEFORMAT,Locale.ENGLISH);		
+		String datePrefix = dateFormat.format(dt);	
+		
+		int pos = buffer.length() + 4;		
+		buffer.append(datePrefix);
+	
+		//  RFC 3164 requires leading space for days 1-9
+		if (buffer.charAt(pos) == '0') {
+			buffer.setCharAt(pos,' ');
+		}
+	}
+	
+	@Override
+	public void send(SyslogIF syslog, int level, Message msg) {
+		StringBuilder out = new StringBuilder();
+		//appendHeader(msg, out);
+
+
+		Date dt = null;
+		Object ts = msg.getField("timestamp");
+		if (ts != null && ts instanceof Number) {
+			dt = new Date(((Number) ts).longValue());
+		}
+		
+		if (dt == null) {
+			dt = new Date();
+		}
+
+    out.append("MSWinEventLog").append(SEPARATOR);
+    appendCriticality(msg, out);
+    appendField(msg, out, "Channel");
+    appendField(msg, out, "RecordNumber"); // we do not have snare counter
+		// Write time
+		appendMSEventTimestamp(dt, out);
+		out.append(SEPARATOR);
+
+    appendField(msg, out, "EventID");
+
+    appendField(msg, out, "SourceName");
+    appendWinUser(msg, out);
+    appendField(msg, out, "AccountType");
+
+    appendField(msg, out, "EventType");
+
+    appendField(msg, out, "source");
+    appendField(msg, out, "Category");
+
+    // manca il data
+    out.append(SEPARATOR);
+
+    // ExtendedData
+    appendField(msg, out, "message");
+
+    Object fld = msg.getField("RecordNumber");
+    if (fld == null){
+      fld = new String("N/A");
+    }
+    out.append(fld.toString());
+
+	  //out.append(msg.getMessage());
+		String str = out.toString();
+		// log.info("Sending plain message: " + level + ", " + str);
+		syslog.log(level, str);
+	}
+
+	public static void appendHeader(Message msg, StringBuilder out) {
+		Date dt = null;
+		Object ts = msg.getField("timestamp");
+		if (ts != null && ts instanceof Number) {
+			dt = new Date(((Number) ts).longValue());
+		}
+		
+		if (dt == null) {
+			dt = new Date();
+		}
+
+    //appendPriority(msg, out);
+
+		// Write time
+		appendSyslogTimestamp(dt, out);
+		out.append(" ");
+
+    Object fld = msg.getField("source");
+    if (fld == null){
+      fld = new String("N/A");
+    }
+    out.append(fld.toString());
+		out.append(" ");
+	}
+
+  public static void appendField(Message msg, StringBuilder out, String field){
+    Object fld = msg.getField(field.toString());
+    if (fld == null){
+      fld = new String("N/A");
+    }
+    String f = fld.toString().replaceAll("\t", " ");
+    out.append(f).append(SEPARATOR);
+  }
+
+  public static void appendWinUser(Message msg, StringBuilder out){
+    Object domain = msg.getField("Domain");
+    if(domain != null){
+      out.append(domain.toString()).append("\\");
+    }
+    appendField(msg, out, "AccountName");
+  }
+
+  public static void appendCriticality(Message msg, StringBuilder out){
+    Object severityValue = msg.getField("SeverityValue");
+    String criticality = "0";
+    if(severityValue!=null){
+      int i_severityValue = Integer.parseInt(severityValue.toString());
+      criticality = String.valueOf(i_severityValue-1);
+    }
+    out.append(criticality.toString()).append(SEPARATOR);
+  }
+
+  public static void appendPriority(Message msg, StringBuilder out){
+    out.append("<").append("14").append(">");
+  }
+}

--- a/src/main/java/com/wizecore/graylog2/plugin/SyslogOutput.java
+++ b/src/main/java/com/wizecore/graylog2/plugin/SyslogOutput.java
@@ -53,10 +53,10 @@ public class SyslogOutput implements MessageOutput {
 			if (fmt == null || fmt.equalsIgnoreCase("plain")) {
 				return new PlainSender();
 			} else
-			if (fmt == null || fmt.equalsIgnoreCase("trasparent syslog")) {
+			if (fmt == null || fmt.equalsIgnoreCase("transparent")) {
 				return new TrasparentSyslogSender(conf);
 			} else
-			if (fmt == null || fmt.equalsIgnoreCase("snare windows")) {
+			if (fmt == null || fmt.equalsIgnoreCase("snare")) {
 				return new SnareWindowsSender();
 			} else
 			if (fmt == null || fmt.equalsIgnoreCase("structured")) {
@@ -260,8 +260,8 @@ public class SyslogOutput implements MessageOutput {
       types.put("structured", "structured");
       types.put("cef", "cef");
       types.put("full", "full");
-      types.put("trasparent syslog", "trasparent syslog");
-      types.put("snare windows", "snare windows");
+      types.put("transparent", "transparent");
+      types.put("snare", "snare");
 
 			final Map<String, String> formats = ImmutableMap.copyOf(types);
 			configurationRequest.addField(new DropdownField(

--- a/src/main/java/com/wizecore/graylog2/plugin/SyslogOutput.java
+++ b/src/main/java/com/wizecore/graylog2/plugin/SyslogOutput.java
@@ -14,6 +14,7 @@ import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.graylog2.plugin.configuration.fields.ConfigurationField;
 import org.graylog2.plugin.configuration.fields.DropdownField;
 import org.graylog2.plugin.configuration.fields.TextField;
+import org.graylog2.plugin.configuration.fields.BooleanField;
 import org.graylog2.plugin.outputs.MessageOutput;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.syslog4j.Syslog;
@@ -47,13 +48,13 @@ public class SyslogOutput implements MessageOutput {
 	private String format;
 	private MessageSender sender;
 
-	public static MessageSender createSender(String fmt) {
+	public static MessageSender createSender(String fmt, Configuration conf) {
 		try {
 			if (fmt == null || fmt.equalsIgnoreCase("plain")) {
 				return new PlainSender();
 			} else
 			if (fmt == null || fmt.equalsIgnoreCase("trasparent syslog")) {
-				return new TrasparentSyslogSender();
+				return new TrasparentSyslogSender(conf);
 			} else
 			if (fmt == null || fmt.equalsIgnoreCase("snare windows")) {
 				return new SnareWindowsSender();
@@ -142,7 +143,7 @@ public class SyslogOutput implements MessageOutput {
 		String hash = protocol + "_" + host + "_" + port + "_" + format;
 		syslog = Syslog.exists(hash) ? Syslog.getInstance(hash) : Syslog.createInstance(hash, config);
 
-		sender = createSender(format);
+		sender = createSender(format, conf);
 		if (sender instanceof StructuredSender) {
 			// Always send via structured data
 			syslog.getConfig().setUseStructuredData(true);
@@ -268,6 +269,7 @@ public class SyslogOutput implements MessageOutput {
 					"Message format. For detailed explanation, see https://github.com/wizecore/graylog2-output-syslog",
 					ConfigurationField.Optional.NOT_OPTIONAL)
 			);
+      configurationRequest.addField(new BooleanField("removeHeader", "Remove header (only Transparent Syslog)", false, "Do not insert timestamp header when it forwards the message content."));
 
 			configurationRequest.addField(new TextField("maxlen", "Maximum message length", "", "Maximum message (body) length. Longer messages will be truncated. If not specified defaults to 16384 bytes.", ConfigurationField.Optional.OPTIONAL));
 			

--- a/src/main/java/com/wizecore/graylog2/plugin/SyslogOutput.java
+++ b/src/main/java/com/wizecore/graylog2/plugin/SyslogOutput.java
@@ -3,6 +3,7 @@ package com.wizecore.graylog2.plugin;
 
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.logging.Logger;
 
 import javax.inject.Inject;
@@ -50,6 +51,12 @@ public class SyslogOutput implements MessageOutput {
 		try {
 			if (fmt == null || fmt.equalsIgnoreCase("plain")) {
 				return new PlainSender();
+			} else
+			if (fmt == null || fmt.equalsIgnoreCase("trasparent syslog")) {
+				return new TrasparentSyslogSender();
+			} else
+			if (fmt == null || fmt.equalsIgnoreCase("snare windows")) {
+				return new SnareWindowsSender();
 			} else
 			if (fmt == null || fmt.equalsIgnoreCase("structured")) {
 				return new StructuredSender();
@@ -247,7 +254,15 @@ public class SyslogOutput implements MessageOutput {
 			configurationRequest.addField(new TextField("host", "Syslog host", "localhost", "Remote host to send syslog messages to.", ConfigurationField.Optional.NOT_OPTIONAL));
 			configurationRequest.addField(new TextField("port", "Syslog port", "514", "Syslog port on the remote host. Default is 514.", ConfigurationField.Optional.NOT_OPTIONAL));
 
-			final Map<String, String> formats = ImmutableMap.of("plain", "plain", "structured", "structured", "cef", "cef", "full", "full");
+      HashMap<String, String> types = new HashMap<String,String>();
+      types.put("plain", "plain");
+      types.put("structured", "structured");
+      types.put("cef", "cef");
+      types.put("full", "full");
+      types.put("trasparent syslog", "trasparent syslog");
+      types.put("snare windows", "snare windows");
+
+			final Map<String, String> formats = ImmutableMap.copyOf(types);
 			configurationRequest.addField(new DropdownField(
 					"format", "Message format", "plain", formats,
 					"Message format. For detailed explanation, see https://github.com/wizecore/graylog2-output-syslog",

--- a/src/main/java/com/wizecore/graylog2/plugin/TrasparentSyslogSender.java
+++ b/src/main/java/com/wizecore/graylog2/plugin/TrasparentSyslogSender.java
@@ -1,0 +1,75 @@
+package com.wizecore.graylog2.plugin;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.logging.Logger;
+
+import org.graylog2.plugin.Message;
+import org.graylog2.syslog4j.SyslogIF;
+
+/**
+ * Formats fields into message text 
+ * 
+
+        <34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 - BOM'su root' failed for lonvick on /dev/pts/8
+         ^priority
+         	^ version
+         	  ^ date 
+         	  						   ^ host
+         	  						   						 ^ APP-NAME
+         	  						   						 	^ structured data?
+         	  						   						 	  ^ MSGID 
+         	  						   						 	  	    
+ */
+public class TrasparentSyslogSender implements MessageSender {
+	private Logger log = Logger.getLogger(TrasparentSyslogSender.class.getName());
+
+	public static final String SYSLOG_DATEFORMAT = "MMM dd HH:mm:ss";
+	
+	/**
+	 * From syslog4j
+	 * 
+	 * @param dt
+	 * @return
+	 */
+	public static void appendSyslogTimestamp(Date dt, StringBuilder buffer) {
+		SimpleDateFormat dateFormat = new SimpleDateFormat(SYSLOG_DATEFORMAT,Locale.ENGLISH);		
+		String datePrefix = dateFormat.format(dt);	
+		
+		int pos = buffer.length() + 4;		
+		buffer.append(datePrefix);
+	
+		//  RFC 3164 requires leading space for days 1-9
+		if (buffer.charAt(pos) == '0') {
+			buffer.setCharAt(pos,' ');
+		}
+	}
+	
+	@Override
+	public void send(SyslogIF syslog, int level, Message msg) {
+		StringBuilder out = new StringBuilder();
+		appendHeader(msg, out);
+		
+		out.append(msg.getMessage());
+		String str = out.toString();
+		// log.info("Sending plain message: " + level + ", " + str);
+		syslog.log(level, str);
+	}
+
+	public static void appendHeader(Message msg, StringBuilder out) {
+		Date dt = null;
+		Object ts = msg.getField("timestamp");
+		if (ts != null && ts instanceof Number) {
+			dt = new Date(((Number) ts).longValue());
+		}
+		
+		if (dt == null) {
+			dt = new Date();
+		}
+		
+		// Write time
+		appendSyslogTimestamp(dt, out);
+		out.append(" ");
+	}
+}

--- a/src/main/java/com/wizecore/graylog2/plugin/TrasparentSyslogSender.java
+++ b/src/main/java/com/wizecore/graylog2/plugin/TrasparentSyslogSender.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.logging.Logger;
 
+import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.Message;
 import org.graylog2.syslog4j.SyslogIF;
 
@@ -24,8 +25,13 @@ import org.graylog2.syslog4j.SyslogIF;
  */
 public class TrasparentSyslogSender implements MessageSender {
 	private Logger log = Logger.getLogger(TrasparentSyslogSender.class.getName());
+  private boolean removeHeader = false;
 
 	public static final String SYSLOG_DATEFORMAT = "MMM dd HH:mm:ss";
+
+  public TrasparentSyslogSender(Configuration conf){
+    removeHeader = conf.getBoolean("removeHeader");
+  }
 	
 	/**
 	 * From syslog4j
@@ -49,7 +55,9 @@ public class TrasparentSyslogSender implements MessageSender {
 	@Override
 	public void send(SyslogIF syslog, int level, Message msg) {
 		StringBuilder out = new StringBuilder();
-		appendHeader(msg, out);
+		if(removeHeader!=true){
+      appendHeader(msg, out);
+    }
 		
 		out.append(msg.getMessage());
 		String str = out.toString();


### PR DESCRIPTION
We add two new senders:

- Transparent one, similiar to plain but with less information
- Snare windows forwarder: rebuild the original snare log message from windows events system

These two senders are useful to forward logs to other log receivers or SIEM solutions.

