### PR TITLE
Fix snare timestamp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@
             <version>1.7.21</version>
 			<scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.10.12</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/wizecore/graylog2/plugin/SyslogOutput.java
+++ b/src/main/java/com/wizecore/graylog2/plugin/SyslogOutput.java
@@ -193,6 +193,21 @@ public class SyslogOutput implements MessageOutput {
 			syslog.getConfig().setSendLocalName(false);
 			syslog.getConfig().setSendLocalTimestamp(false);
 		}
+
+		if (sender instanceof SnareWindowsSender) {
+			// Always send empty header, which we will construct ourselves
+			syslog.setMessageProcessor(new SyslogMessageProcessor() {
+				@Override
+				public String createSyslogHeader(int facility, int level, String localName, boolean sendLocalName, Date datetime) {
+					return "";
+				}
+
+				@Override
+				public String createSyslogHeader(int facility, int level, String localName, boolean sendLocalTimestamp, boolean sendLocalName) {
+					return "";
+				}
+			});
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Hi, I have updated the snare windows sender to include the timestamp from the original Windows messages (e.g. as provided by NXLog in Snare format). 

I have tested it and it provides the following additional features:
- hostname of the snare message in the original message is retained in the syslog header
- timestamp of the snare message in the original message is retained in the syslog and snare headers

Best,
Marco