### PR TITLE
Fix memory leak by limiting internal message queue size

### DIFF
--- a/src/main/java/com/wizecore/graylog2/plugin/SyslogOutput.java
+++ b/src/main/java/com/wizecore/graylog2/plugin/SyslogOutput.java
@@ -338,7 +338,7 @@ public class SyslogOutput implements MessageOutput {
 
 			configurationRequest.addField(new TextField("maxlen", "Maximum message length", "", "Maximum message (body) length. Longer messages will be truncated. If not specified defaults to 16384 bytes.", ConfigurationField.Optional.OPTIONAL));
 
-			configurationRequest.addField(new TextField("maxQueueSize", "Maximum queue size", "500", "Maximum number of messages to queue internally before blocking (prevents OOM). Set to -1 for unlimited (not recommended). Default is 500.", ConfigurationField.Optional.OPTIONAL));
+			configurationRequest.addField(new TextField("maxQueueSize", "Maximum queue size", "500", "Maximum number of messages to queue internally. Set to -1 for unlimited. Default is 500.", ConfigurationField.Optional.OPTIONAL));
 
 			configurationRequest.addField(new TextField("keystore", "Key store", "", "Path to Java keystore (required for SSL over TCP). Must contain private key and cert for this client.", ConfigurationField.Optional.OPTIONAL));
 			configurationRequest.addField(new TextField("keystorePassword", "Key store password", "", "", ConfigurationField.Optional.OPTIONAL));

--- a/src/main/java/com/wizecore/graylog2/plugin/SyslogOutput.java
+++ b/src/main/java/com/wizecore/graylog2/plugin/SyslogOutput.java
@@ -102,7 +102,7 @@ public class SyslogOutput implements MessageOutput {
 		log.info("Creating syslog output " + protocol + "://" + host + ":" + port + ", format " + format);
 		SyslogConfigIF config = null;
 		if (protocol.toLowerCase().equals("udp")) {
-			UDPNetSyslogConfig updConfig = new UDPNetSyslogConfig();
+			UDPNetSyslogConfig udpConfig = new UDPNetSyslogConfig();
             udpConfig.setMaxQueueSize(maxQueueSize);
             config = udpConfig;
 		} else


### PR DESCRIPTION
This commit addresses GitHub issue #61 where memory usage keeps increasing and garbage collection fails, eventually causing node crashes after several days.

Root Cause:
The syslog4j library queues messages internally with no limit by default when using TCP/SSL protocols. Under high message throughput, this causes unbounded memory growth leading to OOM errors.

Solution:
1. Added maxQueueSize configuration parameter (default: 500 messages)
2. Set maxQueueSize on all syslog config objects (UDP/TCP/SSL)
3. Made the parameter user-configurable through Graylog UI

The conservative default of 500 prevents memory leaks while still allowing reasonable buffering. Users experiencing high throughput can tune this value based on their needs, but should avoid unlimited queuing (-1).

When the queue is full, the plugin will block until space is available, providing natural backpressure instead of consuming all available memory.

Configuration:
- Default: 500 messages
- Configurable via "Maximum queue size" field in output configuration
- Set to -1 for unlimited (not recommended, will cause OOM)

Fixes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)